### PR TITLE
Fixes warning that :background nil value is invalid.

### DIFF
--- a/sideline-blame.el
+++ b/sideline-blame.el
@@ -93,7 +93,7 @@
 
 (defface sideline-blame
   '((t :foreground "#7a88cf"
-       :background nil
+       :background unspecified
        :italic t))
   "Face for blame info."
   :group 'sideline-blame)


### PR DESCRIPTION
`Warning: setting attribute ‘:background’ of face ‘sideline-blame’: nil value is invalid, use ‘unspecified’ instead.`