### PR TITLE
fix: Add guard for buffer is associated a file and file is vc backed

### DIFF
--- a/sideline-blame.el
+++ b/sideline-blame.el
@@ -109,31 +109,32 @@ Argument COMMAND is required in sideline backend."
 
 (defun sideline-blame--get-message ()
   "Return the blame message."
-  (when-let*
-      ((plugin (vc-msg-find-plugin))
-       (current-file (funcall vc-msg-get-current-file-function))
-       (executer (plist-get plugin :execute))
-       (formatter (plist-get plugin :format))
-       (commit-info (and current-file
-                         (funcall executer
-                                  current-file
-                                  (funcall vc-msg-get-line-num-function)
-                                  (funcall vc-msg-get-version-function)))))
-    (let* ((id (plist-get commit-info :id))
-           (uncommitted (or (null id)
-                            (null (string-match-p "[^0]" id))))
-           (author (if uncommitted sideline-blame-uncommitted-author-name
-                     (plist-get commit-info :author)))
-           (time (unless uncommitted
-                   (ignore-errors
-                     (string-to-number (plist-get commit-info :author-time)))))
-           (summary (if uncommitted sideline-blame-uncommitted-message
-                      (plist-get commit-info :summary))))
-      (concat (format sideline-blame-author-format author)
-              (if uncommitted
-                  sideline-blame-uncommitted-time
-                (format-time-string sideline-blame-datetime-format time))
-              (format sideline-blame-commit-format summary)))))
+  (when (and buffer-file-name (vc-backend buffer-file-name))
+    (when-let*
+        ((plugin (vc-msg-find-plugin))
+         (current-file (funcall vc-msg-get-current-file-function))
+         (executer (plist-get plugin :execute))
+         (formatter (plist-get plugin :format))
+         (commit-info (and current-file
+                           (funcall executer
+                                    current-file
+                                    (funcall vc-msg-get-line-num-function)
+                                    (funcall vc-msg-get-version-function)))))
+      (let* ((id (plist-get commit-info :id))
+             (uncommitted (or (null id)
+                              (null (string-match-p "[^0]" id))))
+             (author (if uncommitted sideline-blame-uncommitted-author-name
+                       (plist-get commit-info :author)))
+             (time (unless uncommitted
+                     (ignore-errors
+                       (string-to-number (plist-get commit-info :author-time)))))
+             (summary (if uncommitted sideline-blame-uncommitted-message
+                        (plist-get commit-info :summary))))
+        (concat (format sideline-blame-author-format author)
+                (if uncommitted
+                    sideline-blame-uncommitted-time
+                  (format-time-string sideline-blame-datetime-format time))
+                (format sideline-blame-commit-format summary))))))
 
 (defun sideline-blame--display (callback &rest _)
   "Execute CALLBACK to display with sideline."


### PR DESCRIPTION
Added guard to check that `buffer-file-name` is non-nil (buffer is associated with file).

Added another guard to make sure that the `buffer-file-name` is backed by a `vc-backend`.